### PR TITLE
Run jekyll:build before deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Require in *Capfile* to use the default task:
 ```ruby
 require 'capistrano/jekyll'
 ```  
-**jekyll:build** task will run after **deploy:symlink:release** as part of Capistrano's default deploy, or can be run in isolation with `bundle exec cap production jekyll:build`
+**jekyll:build** task will run after **deploy:updated** as part of Capistrano's default deploy, or can be run in isolation with `bundle exec cap production jekyll:build`
 
 ### List of tasks
-* `cap jekyll:build # Build your website`
-* `cap jekyll:doctor # Search site and print specific deprecation warnings`
+* `cap jekyll:build # Build the website using Jekyll`
+* `cap jekyll:doctor # Print Jekyll deprecation warnings`
 
 ## Contributing
 

--- a/lib/capistrano/tasks/jekyll.rake
+++ b/lib/capistrano/tasks/jekyll.rake
@@ -1,22 +1,22 @@
 desc 'Jekyll integration'
 namespace :jekyll do
-  desc 'Build your website'
+  desc 'Build the website using Jekyll'
   task :build do
     on roles(:web) do
-      within current_path do
+      within release_path do
         execute :jekyll, 'build'
       end
     end
   end
 
-  desc 'Search site and print specific deprecation warnings'
+  desc 'Print Jekyll deprecation warnings'
   task :doctor do
     on roles(:web) do
-      within current_path do
+      within release_path do
         execute :jekyll, 'doctor'
       end
     end
   end
 
-  after 'deploy:symlink:release', :build
+  after 'deploy:updated', :build
 end


### PR DESCRIPTION
Currently the `jekyll:build` task is run after the new release has been made live. This is incredibly bad because:
1. The site is unavailable from the time the symlink is changed until Jekyll builds the site.
2. If Jekyll fails, it leaves the site completely broken.

Following the [Capistrano documentation](http://capistranorb.com/documentation/getting-started/flow/), this performs the `jekyll:build` step after `deploy:updated`, so that it will be built before the `current` symlink is updated, and upon failure, the site will not be left in a broken state.
