### PR TITLE
Make task invocation in after hook namespace aware

### DIFF
--- a/lib/capistrano/tasks/jekyll.rake
+++ b/lib/capistrano/tasks/jekyll.rake
@@ -18,5 +18,5 @@ namespace :jekyll do
     end
   end
 
-  after 'deploy:updated', :build
+  after 'deploy:updated', 'jekyll:build'
 end


### PR DESCRIPTION
Capistrano 3.5.0 requires that after hooks are namespace aware. Check [changelog](https://github.com/capistrano/capistrano/blob/master/CHANGELOG.md#potentially-breaking-changes) and https://github.com/capistrano/capistrano/issues/1652
